### PR TITLE
Fix order of imports

### DIFF
--- a/grade/internal/domain/artifact/artifact.go
+++ b/grade/internal/domain/artifact/artifact.go
@@ -1,9 +1,9 @@
 package artifact
 
 import (
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/expertisearea"
 	"time"
 
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/expertisearea"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 )
 

--- a/grade/internal/domain/endorsed/endorsed.go
+++ b/grade/internal/domain/endorsed/endorsed.go
@@ -2,9 +2,9 @@ package endorsed
 
 import (
 	"errors"
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
 	"time"
 
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/endorsed/endorsement"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/endorsed/gradelogentry"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"

--- a/grade/internal/domain/endorsed/endorsed_exporter.go
+++ b/grade/internal/domain/endorsed/endorsed_exporter.go
@@ -1,11 +1,12 @@
 package endorsed
 
 import (
+	"time"
+
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/endorsed/endorsement"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/endorsed/gradelogentry"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
-	"time"
 )
 
 type EndorsedExporter struct {

--- a/grade/internal/domain/endorsed/endorsed_fake_factory.go
+++ b/grade/internal/domain/endorsed/endorsed_fake_factory.go
@@ -1,11 +1,12 @@
 package endorsed
 
 import (
+	"time"
+
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/recognizer"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/shared"
-	"time"
 )
 
 func NewEndorsedFakeFactory() *EndorsedFakeFactory {

--- a/grade/internal/domain/endorsed/endorsed_receive_endorsement_test.go
+++ b/grade/internal/domain/endorsed/endorsed_receive_endorsement_test.go
@@ -2,12 +2,12 @@ package endorsed
 
 import (
 	"fmt"
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/endorsed/endorsement"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/recognizer"
 )

--- a/grade/internal/domain/endorsed/endorsed_test.go
+++ b/grade/internal/domain/endorsed/endorsed_test.go
@@ -1,13 +1,15 @@
 package endorsed
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/endorsed/endorsement"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/endorsed/gradelogentry"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/recognizer"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestEndorsedExport(t *testing.T) {

--- a/grade/internal/domain/endorsed/endorsement/endorsement.go
+++ b/grade/internal/domain/endorsed/endorsement/endorsement.go
@@ -2,11 +2,12 @@ package endorsement
 
 import (
 	"errors"
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
-	"github.com/hashicorp/go-multierror"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/shared"
 )

--- a/grade/internal/domain/endorsed/endorsement/endorsement_exporter.go
+++ b/grade/internal/domain/endorsed/endorsement/endorsement_exporter.go
@@ -1,9 +1,10 @@
 package endorsement
 
 import (
+	"time"
+
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
-	"time"
 )
 
 type EndorsementExporter struct {

--- a/grade/internal/domain/endorsed/endorsement/endorsement_fake_factory.go
+++ b/grade/internal/domain/endorsed/endorsement/endorsement_fake_factory.go
@@ -1,10 +1,10 @@
 package endorsement
 
 import (
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"time"
 
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/shared"
 )
 

--- a/grade/internal/domain/endorsed/endorsement/endorsement_test.go
+++ b/grade/internal/domain/endorsed/endorsement/endorsement_test.go
@@ -2,11 +2,11 @@ package endorsement
 
 import (
 	"fmt"
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/artifact"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/shared"

--- a/grade/internal/domain/endorsed/gradelogentry/grade_log_entry.go
+++ b/grade/internal/domain/endorsed/gradelogentry/grade_log_entry.go
@@ -1,9 +1,9 @@
 package gradelogentry
 
 import (
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"time"
 
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/shared"
 )

--- a/grade/internal/domain/endorsed/gradelogentry/grade_log_entry_exporter.go
+++ b/grade/internal/domain/endorsed/gradelogentry/grade_log_entry_exporter.go
@@ -1,9 +1,10 @@
 package gradelogentry
 
 import (
+	"time"
+
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
-	"time"
 )
 
 type GradeLogEntryExporter struct {

--- a/grade/internal/domain/endorsed/gradelogentry/grade_log_entry_fake_factory.go
+++ b/grade/internal/domain/endorsed/gradelogentry/grade_log_entry_fake_factory.go
@@ -1,9 +1,9 @@
 package gradelogentry
 
 import (
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"time"
 
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/shared"
 )
 

--- a/grade/internal/domain/endorsed/gradelogentry/grade_log_entry_test.go
+++ b/grade/internal/domain/endorsed/gradelogentry/grade_log_entry_test.go
@@ -1,11 +1,12 @@
 package gradelogentry
 
 import (
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"testing"
 
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 )
 
 func TestGradeLogEntryExport(t *testing.T) {

--- a/grade/internal/domain/member/tenant_member_id_test.go
+++ b/grade/internal/domain/member/tenant_member_id_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 )
 
 func TestTenantMemberIdEquals(t *testing.T) {

--- a/grade/internal/domain/recognizer/endorsement_count.go
+++ b/grade/internal/domain/recognizer/endorsement_count.go
@@ -3,6 +3,7 @@ package recognizer
 import (
 	"errors"
 	"fmt"
+
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 )
 

--- a/grade/internal/domain/recognizer/endorsement_count_test.go
+++ b/grade/internal/domain/recognizer/endorsement_count_test.go
@@ -2,9 +2,11 @@ package recognizer
 
 import (
 	"fmt"
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 )
 
 func TestEndorsementCountConstructor(t *testing.T) {

--- a/grade/internal/domain/recognizer/recognizer_exporter.go
+++ b/grade/internal/domain/recognizer/recognizer_exporter.go
@@ -1,9 +1,10 @@
 package recognizer
 
 import (
+	"time"
+
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
-	"time"
 )
 
 type RecognizerExporter struct {

--- a/grade/internal/domain/recognizer/recognizer_fake_factory.go
+++ b/grade/internal/domain/recognizer/recognizer_fake_factory.go
@@ -1,9 +1,10 @@
 package recognizer
 
 import (
+	"time"
+
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/member"
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/shared"
-	"time"
 )
 
 func NewRecognizerFakeFactory() *RecognizerFakeFactory {

--- a/grade/internal/domain/seedwork/versioned_aggregate_test.go
+++ b/grade/internal/domain/seedwork/versioned_aggregate_test.go
@@ -1,8 +1,9 @@
 package seedwork
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionedAggregateConstructor(t *testing.T) {

--- a/grade/internal/domain/shared/grade.go
+++ b/grade/internal/domain/shared/grade.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"errors"
 	"fmt"
+
 	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 )
 

--- a/grade/internal/domain/shared/grade_test.go
+++ b/grade/internal/domain/shared/grade_test.go
@@ -2,9 +2,11 @@ package shared
 
 import (
 	"fmt"
-	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/emacsway/qualifying-grade/grade/internal/domain/seedwork"
 )
 
 func TestGradeConstructor(t *testing.T) {


### PR DESCRIPTION
There are several issues in import order and goimports linter
forces reordering of them.

Let's keep our source code compliant to linter rules.